### PR TITLE
pipe.fd can be -1

### DIFF
--- a/split.cc
+++ b/split.cc
@@ -124,8 +124,12 @@ int split_main(int argc, char* argv[]) {
     }
 
     for(auto& pipe : pipes) {
-      if(FD_ISSET(pipe.fd, &output_set) && !pipe.append_sequence(input))
+      if (pipe.fd == -1){
         pipe.close();
+      } else {
+        if(FD_ISSET(pipe.fd, &output_set) && !pipe.append_sequence(input))
+          pipe.close();
+      }
     }
   }
 


### PR DESCRIPTION
FD_ISSET(pipe.fd, &output_set) gives a buffer overflow when pipe.fd is -1.